### PR TITLE
Add a meaningful description 

### DIFF
--- a/sensu-plugins-cassandra.gemspec
+++ b/sensu-plugins-cassandra.gemspec
@@ -15,7 +15,12 @@ Gem::Specification.new do |s|
   s.authors                = ['Sensu Plugins and contributors']
   s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
-  s.description            = 'Sensu plugins for the Cassandra NoSQL database server'
+  s.description            = 'This plugin provides native Cassandra
+                              instrumentation for monitoring and metrics
+                              collection, including: service health, database
+                              connectivity, and various `nodetool` checks (e.g.
+                              schema disagreement, `tpstats` metrics, etc) and
+                              more.'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*').map { |file| File.basename(file) }
   s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)


### PR DESCRIPTION
We are going to publish a new /plugins page on the Sensu website and we would like to source the plugin descriptions from the gemspecs so that all of the descriptions will be in sync (i.e. github, rubygems, website). 

The actual description itself is open for discussion or suggestions. I'd like to keep it to a few short sentences that provide a high-level overview of the functionality provided by the plugin. 
