### PR TITLE
Fix key cache parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
+- Added key cache parsing for newer nodetool version
+
+### Added
 - Support Ruby 2.4.1
 
 ## [1.0.0] - 2016-11-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Added
-- Added key cache parsing for newer nodetool version
 
 ### Added
 - Support Ruby 2.4.1
+- Added key cache parsing for newer nodetool version
 
 ## [1.0.0] - 2016-11-26
 ### Changed

--- a/bin/metrics-cassandra-graphite.rb
+++ b/bin/metrics-cassandra-graphite.rb
@@ -218,6 +218,17 @@ class CassandraMetrics < Sensu::Plugin::Metric::CLI::Graphite
         output "#{config[:scheme]}.key_cache.requests", m[4], @timestamp
       end
 
+      # cassandra nodetool v3.0+  Changed the key cache output
+      # Key Cache : entries 569669, size 100 MiB, capacity 100 MiB, 35689224 hits, 70654365 requests, 0.505 recent hit rate, 14400 save period in seconds
+      # Key Cache : entries 13291, size 7.83 MB, capacity 50 MB, 119444 hits, 139720 requests, 0.855 recent hit rate, 14400 save period in seconds
+      if m = line.match(/^Key Cache[^:]+: entries ([0-9]+), size ([-+]?[0-9]*\.?[0-9]+) ([KMGT]i?B|bytes), capacity ([-+]?[0-9]*\.?[0-9]+) ([KMGT]i?B|bytes), ([0-9]+) hits, ([0-9]+) requests, ([-+]?[0-9]*\.?[0-9]+) recent hit rate/)# rubocop:disable all
+        output "#{config[:scheme]}.key_cache.size", convert_to_bytes(m[2], m[3]), @timestamp
+        output "#{config[:scheme]}.key_cache.capacity", convert_to_bytes(m[4], m[5]), @timestamp
+        output "#{config[:scheme]}.key_cache.hits", m[6], @timestamp
+        output "#{config[:scheme]}.key_cache.requests", m[7], @timestamp
+        output "#{config[:scheme]}.key_cache.hit_rate", m[8], @timestamp
+      end
+
       if m = line.match(/^Row Cache[^:]+: size ([0-9]+) \(bytes\), capacity ([0-9]+) \(bytes\), ([0-9]+) hits, ([0-9]+) requests/)# rubocop:disable all
         output "#{config[:scheme]}.row_cache.size", m[1], @timestamp
         output "#{config[:scheme]}.row_cache.capacity", m[2], @timestamp


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#7 key_cache related metrics is not captured with nodetool info command due to regex mismatch

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] RuboCop passes 

- [x] Existing tests pass 

#### Purpose

Update parser for nodetool to pull key cache stats

#### Known Compatibility Issues

N/A