### PR TITLE
Modify metric sanitization

### DIFF
--- a/bin/metrics-cassandra-graphite.rb
+++ b/bin/metrics-cassandra-graphite.rb
@@ -347,7 +347,8 @@ class CassandraMetrics < Sensu::Plugin::Metric::CLI::Graphite
         metric.gsub!(/[_]{2,}/, '_')       # convert sequence of multiple _'s to single _
         metric.downcase!
         # sanitize metric values for graphite. Numbers only, please.
-        value = value.chomp(' ms.').gsub(/([0-9.]+)$/, '\1')
+        # some versions of nodetool omit the '.' following the 'ms' unit.
+        value = value.chomp(' ms.').chomp(' ms').gsub(/([0-9.]+)$/, '\1')
       end
       [metric, value]
     end

--- a/bin/metrics-cassandra-graphite.rb
+++ b/bin/metrics-cassandra-graphite.rb
@@ -348,7 +348,7 @@ class CassandraMetrics < Sensu::Plugin::Metric::CLI::Graphite
         metric.downcase!
         # sanitize metric values for graphite. Numbers only, please.
         # some versions of nodetool omit the '.' following the 'ms' unit.
-        value = value.chomp(' ms.').chomp(' ms').gsub(/([0-9.]+)$/, '\1')
+        value = value.chomp(' ms.').chomp(' ms')
       end
       [metric, value]
     end


### PR DESCRIPTION
Earlier versions of nodetool incorrectly append a '.' to the 'ms' SI unit.  In newer versions where this has been corrected, the missing '.' failed to match causing a missed 'chomp' operation.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out in [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
